### PR TITLE
Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,23 @@
 # Ember-cli-fxos
 
-This is an [ember-cli](http://www.ember-cli.com/) add-on for creating FireFox OS applications. 
+This is an [Ember CLI](http://www.ember-cli.com/) add-on for creating FireFox OS applications. 
 
 ## Installation
-If you are using Ember CLI >= 0.1.5:
+From the root of your Ember CLI project:
 
 ```
 ember install:addon ember-cli-fxos
 ```
 
-If you are using Ember CLI < 0.1.5:
-
-```
-npm install ember-cli-fxos --save-dev
-```
-
-## Creating Your Manifest File
+## Configuration
+### Manifest File
 Every FireFox OS application requires a [manifest file](https://developer.mozilla.org/en-US/Apps/Build/Manifest) in the root of your project.
 
-If you are using Ember CLI >= 0.1.5, the manifest file has already been created for you. If you are using an older version of Ember CLI, you can generate this file with the following command:
+After installing the addon, you'll see a `manifest.webapp` file was created in your application's /public directory. Any values that start with `@@` (e.g. `@@appName`) will be pulled from your `package.json` at build time. Reference the MDN link above for additional information on configuring your manifest file.
 
-```
-ember g fxos-manifest
-```
+## Validation
+After running `ember build`, your final manifest file will be compiled into the /dist directory. To validate the manifest file and check for any errors or warnings, run:
 
-This will create a `manifest.webapp` file in your application's /public directory. Any values that start with `@@` (e.g. `@@appName`) will be pulled from your `package.json` at build time.
+`ember fxos:validate`
+
+*Note: The [module performing validation](https://github.com/mozilla/firefox-app-validator-manifest) is still a work in progress. It may not catch all errors. Please do file bugs as you encounter them.*

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ ember install:addon ember-cli-fxos
 ### Manifest File
 Every FireFox OS application requires a [manifest file](https://developer.mozilla.org/en-US/Apps/Build/Manifest) in the root of your project.
 
-After installing the addon, you'll see a `manifest.webapp` file was created in your application's /public directory. Any values that start with `@@` (e.g. `@@appName`) will be pulled from your `package.json` at build time. Reference the MDN link above for additional information on configuring your manifest file.
+This addon creates a `manifest.webapp` in your application's `/public` directory. Any values that start with `@@` (e.g. `@@appName`) will be pulled from your `package.json` at build time. Reference [MDN](https://developer.mozilla.org/en-US/Apps/Build/Manifest) for additional information on configuring your manifest file.
 
 ## Validation
-After running `ember build`, your final manifest file will be compiled into the /dist directory. To validate the manifest file and check for any errors or warnings, run:
+After running `ember build`, your final manifest file will be compiled into the `/dist` directory. To validate the manifest file and check for any errors or warnings, run:
 
 `ember fxos:validate`
 

--- a/index.js
+++ b/index.js
@@ -4,11 +4,15 @@ var replace = require('broccoli-replace');
 var pickFiles = require('broccoli-static-compiler');
 var mergeTrees = require('broccoli-merge-trees');
 var parseAuthor = require('parse-author');
+var commands = require('./lib/commands');
 
 module.exports = {
     name: 'ember-cli-fxos',
     included: function(app) {
         app.options.wrapInEval = false;
+    },
+    includedCommands: function() {
+        return commands;
     },
     parsePkgAuthor: function(authorData) {
         var developerInfo = {};

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  'fxos:validate': require('./validate')
+};

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var Manifest = require('firefox-app-validator-manifest');
+var readFile = require('fs-readfile-promise');
+var chalk = require('chalk');
+
+function formatErrorDetails(messageType, msgs) {
+  var msg = '';
+  for (var result in msgs) {
+    msg += chalk.red(messageType + ': ' + result + ' - ' + msgs[result] + '\n');
+  }
+  return msg;
+}
+
+module.exports = {
+  name: 'fxos:validate',
+  aliases: ['fxos:valid'],
+  description: 'Validate the manifest file for a Firefox OS Application',
+  works: 'insideProject',
+
+  run: function(options) {
+    var ff = new Manifest();
+
+    return readFile(this.project.root + '/dist/manifest.webapp')
+      .then(function(buffer) {
+        console.log(chalk.blue('Validating /dist/manifest.webapp...'));
+
+        var validation = ff.validate(buffer.toString());
+        var errorsCount = Object.keys(validation.errors).length;
+        var warningsCount = Object.keys(validation.warnings).length;
+        var validationResultMsg = chalk.green('✓ Validation passed');
+        var errorDetails = '';
+
+        if (errorsCount > 0) {
+          validationResultMsg = chalk.red('Validation Failed');
+          errorDetails += formatErrorDetails('Error', validation.errors);
+        }
+
+        if (warningsCount > 0) {
+          errorDetails += formatErrorDetails('Warning', validation.warnings);
+        }
+
+        console.log(validationResultMsg);
+        console.log(errorDetails);
+
+      })
+      .catch(function(err) {
+        if (err.code === 'ENOENT') {
+          console.log(chalk.red('Error: no manifest file found at /dist/manifest.webapp\nTry again after running `ember build`'));
+        }
+        else {
+          console.log(chalk.red(err.message));
+        }
+      });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-replace": "^0.2.0",
     "broccoli-static-compiler": "^0.2.1",
+    "chalk": "^1.0.0",
+    "firefox-app-validator-manifest": "^1.1.7",
+    "fs-readfile-promise": "^1.1.0",
     "parse-author": "^0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds an `ember fxos:validate` command that uses the [firefox-app-validator-manifest](https://github.com/mozilla/firefox-app-validator-manifest) module to validate the processed manifest.webapp file in the /dist directory. (Readme includes a note that the validator is still a WIP and may not catch all errors)